### PR TITLE
Hooker with async/await

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -244,6 +244,20 @@ checkqa_mypy = ["mypy (==0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.14.0"
+description = "Pytest support for asyncio."
+category = "dev"
+optional = false
+python-versions = ">= 3.5"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-cov"
 version = "2.10.1"
 description = "Pytest plugin for measuring coverage."
@@ -301,7 +315,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "851ffa951bbb9f94a9c40c05b8d68a7fbebb154312e39d3893918e2fa3ce57fb"
+content-hash = "55d3d6902f0c5e05539029bdfb3f8de2195bd99247f6cafa00713a4b37dc67f9"
 
 [metadata.files]
 appdirs = [
@@ -434,6 +448,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.14.0.tar.gz", hash = "sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700"},
+    {file = "pytest_asyncio-0.14.0-py3-none-any.whl", hash = "sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ flake8-bugbear = "^20.11.1"
 pytest = "^6.1.2"
 mypy = "^0.790"
 pytest-cov = "^2.10.1"
+pytest-asyncio = "^0.14.0"
 
 [tool.commitizen]
 name = "cz_conventional_commits"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+import pytest
+
 from hookers import hook
 
 
@@ -104,3 +106,24 @@ def test_obj_hooked_method_got_overwrited():
     person.hello = lambda x: f"hello {x}"
     assert isinstance(Person.hello, hook)
     assert person.hello("world") == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_hook_async_func_call_before():
+    @hook
+    async def hello(name):
+        return f"hello {name}"
+
+    args = ("world",)
+    kwargs = {}
+    rv = "hello world"
+
+    inputs = []
+
+    def dump_input(*args, **kwargs):
+        inputs.append((args, kwargs))
+
+    hello.call_before(dump_input)
+
+    assert await hello(*args, **kwargs) == rv
+    assert inputs == [(args, kwargs)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -108,6 +108,18 @@ def test_obj_hooked_method_got_overwrited():
     assert person.hello("world") == "hello world"
 
 
+def test_hook_func_call_before_with_async_func():
+    @hook
+    def hello(name):
+        return f"hello {name}"
+
+    async def async_hook():
+        pass
+
+    with pytest.raises(ValueError):
+        hello.call_before(async_hook)
+
+
 @pytest.mark.asyncio
 async def test_hook_async_func_call_before():
     @hook
@@ -121,6 +133,27 @@ async def test_hook_async_func_call_before():
     inputs = []
 
     def dump_input(*args, **kwargs):
+        inputs.append((args, kwargs))
+
+    hello.call_before(dump_input)
+
+    assert await hello(*args, **kwargs) == rv
+    assert inputs == [(args, kwargs)]
+
+
+@pytest.mark.asyncio
+async def test_hook_async_func_call_before_with_async_func():
+    @hook
+    async def hello(name):
+        return f"hello {name}"
+
+    args = ("world",)
+    kwargs = {}
+    rv = "hello world"
+
+    inputs = []
+
+    async def dump_input(*args, **kwargs):
         inputs.append((args, kwargs))
 
     hello.call_before(dump_input)


### PR DESCRIPTION
- allow adding async hooker if hooking async function
- raise ValueError if adding async hooker while hooking un-async function

For usage examples, please see the unit test cases.